### PR TITLE
apiコンテナにprisma studio用のポートを用意する

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     tty: true
     ports:
       - 3000:3000
+      - 5555:5555
     depends_on:
       - db
     command: npm run start:dev


### PR DESCRIPTION
## 概要
apiコンテナでprismaを導入する際に[prisma studio](https://www.prisma.io/studio) を利用するためのポートを開放する必要があるため設定を追加する


## 参考資料
https://qiita.com/Ryo9597/questions/17fbcac39569b580e677#tl-dr